### PR TITLE
Add Marketplace link + YOLO Export

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Shortcuts for initializing pretrained [Ultralytics models][models], like [YOLOv8
 | Alias                  | Description                            | Reference                                             |
 | ---------------------- | -------------------------------------- | ----------------------------------------------------- |
 | `ultra.yolo-model`     | Shortcut to initialize YOLO model.     | [YOLOv5], [YOLOv8], [YOLOv9], [YOLOv10], [YOLO-World] |
+| `ultra.yolo-export`    | Shortcut to export YOLO model weights. | [Model Export]                                        |
 | `ultra.sam-model`      | Shortcut to initialize SAM.            | [SAM]                                                 |
 | `ultra.mobileam-model` | Shortcut to initialize MobileSAM.      | [Mobile SAM]                                          |
 | `ultra.fastam-model`   | Shortcut to initialize FastSAM.        | [FastSAM]                                             |
@@ -211,3 +212,4 @@ for result in results:
 [results class]: https://docs.ultralytics.com/reference/engine/results/
 [auto ann]: https://docs.ultralytics.com/reference/data/annotator/
 [divisible]: https://docs.ultralytics.com/reference/utils/ops/#ultralytics.utils.ops.make_divisible
+[Model Export]: https://docs.ultralytics.com/modes/export

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Import snippets are for common objects that would be imported from the Ultralyti
 | `ultra.import-seg2bbox`     | Import Ultralytics function to convert segmentation contours into horizontal bounding boxes. |
 | `ultra.import-box-convert`  | Import Ultralytics function for converting bounding box coordinates.                         |
 | `ultra.import-formats`      | Import Ultralytics supported file formats constant.                                          |
+
 ### Snippet Example
 
 <details><summary><code>ultra.import-model</code> Snippet</summary>
@@ -102,6 +103,7 @@ Shortcuts for initializing pretrained [Ultralytics models][models], like [YOLOv8
 | `ultra.fastam-model`   | Shortcut to initialize FastSAM.        | [FastSAM]                                             |
 | `ultra.nas-model`      | Shortcut to initialize YOLO-NAS model. | [YOLO-NAS]                                            |
 | `ultra.rtdetr-model`   | Shortcut to initialize RTDETR model.   | [RTDETR]                                              |
+
 ### Snippet Example
 
 <details><summary><code>ultra.yolo-model</code> Snippet</summary>
@@ -147,7 +149,6 @@ auto_annotate(data="", det_model="yolov8n.pt", sam_model="sam_b.pt", device="cud
 **NOTE**: Each function argument will be a "field" that can be tabbed into and changed. The `det_model`, `sam_model`, and `device` arguments will have options for default models, but can be cleared to input custom strings instead.
 
 </p></details>
-
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   </p>
 </div>
 
-A python snippets extension for VSCode to assist with development using the [Ultralytics package](https://github.com/ultralytics/ultralytics). These snippets will help you code with Ultralytics faster and help provide some boilerplate examples to test out. Open an Issue or a Pull Request to have your snippet added! 🚀
+A [Python snippets extension for VSCode](https://marketplace.visualstudio.com/items?itemName=Ultralytics.ultralytics-snippets) to assist with development using the [Ultralytics package](https://github.com/ultralytics/ultralytics). These snippets will help you code with Ultralytics faster and help provide some boilerplate examples to test out. Open an Issue or a Pull Request to have your snippet added! 🚀
 
 <div align="center">
   <p>
@@ -107,7 +107,7 @@ Shortcuts for initializing pretrained [Ultralytics models][models], like [YOLOv8
 <details><summary><code>ultra.yolo-model</code> Snippet</summary>
 <p>
 
-Drop-down select available for `version`, `scale`, and `task`, equivalent python code shown below
+Drop-down select available for `version`, `scale`, and `task`, equivalent Python code shown below
 
 ```py
 version = 8

--- a/snippets/examples.json
+++ b/snippets/examples.json
@@ -188,6 +188,7 @@
 			"    save_txt=${19:False},      # (bool) save results as .txt file",
 			"    save_conf=${20:False},     # (bool) save results with confidence scores",
 			"    save_crop=${21:False},     # (bool) save cropped images with results",
+			"    stream=${22:False}         # (bool) for processing long videos or numerous images with reduced memory usage by returning a generator",
 			")",
 			"# reference https://docs.ultralytics.com/modes/predict/"
 		],

--- a/snippets/models.json
+++ b/snippets/models.json
@@ -16,6 +16,32 @@
 		"description": "Initialize YOLO model."
 	},
 
+	"Ultralytics YOLO Export": {
+		"prefix": "ultra.yolo-export",
+		"body": [
+			"from ultralytics import YOLO",
+			"",
+			"model = YOLO(\"${1:yolov8n.pt}\", task=\"${2|detect,segment,pose,obb,classify|}\")",
+			"out_file = model.export(",
+			"    format=\"${3|torchscript,onnx,openvino,engine,coreml,pb,tflite,edgetpu,tfjs,paddle,ncnn|}\",",
+			"    imgsz=${4:640},         # (int | list) input images size for exported model",
+			"    batch=${5:1},           # (int) batch size for exported model",
+			"    keras=${6|False,True|},       # (bool) use Keras",
+			"    optimize=${7|False,True|},    # (bool) TorchScript: optimize for mobile",
+			"    half=${8|False,True|},        # (bool) ONNX/TF/TensorRT: FP16 quantization",
+			"    int8=${9|False,True|},        # (bool) CoreML/TF/TensorRT/OpenVino INT8 quantization",
+			"    dynamic=${10|False,True|},     # (bool) ONNX/TF/TensorRT: dynamic axes",
+			"    simplify=${11|False,True|},    # (bool) ONNX: simplify model using `onnxslim`",
+			"    opset=${12:None},        # (int, optional) ONNX: opset version",
+			"    workspace=${13:4},       # (int) TensorRT: workspace size (GiB)",
+			"    nms=${14|False,True|},         # (bool) CoreML: add NMS",
+			")",
+			"# reference https://docs.ultralytics.com/modes/export",
+			"$0"
+		],
+		"description": "Export YOLO model weights to a new format."
+	},
+
 	"Ultralytics SAM Model": {
 		"prefix": "ultra.sam-model",
 		"body": [

--- a/snippets/models.json
+++ b/snippets/models.json
@@ -9,8 +9,9 @@
 			"⚠ NOTE: selections do not prevent you from specifying a combination for a model that doesn't exist.",
 			"Reference the documentation for valid model specifications: https://docs.ultralytics.com/models",
 			"'''",
-			"model = YOLO(\"yolov${2|8,5,9,10|}${3|n,s,m,l,x,c,e|}${4|.,-cls.,-seg.,-obb.,-pose.,-world.,-worldv2.|}pt\")",
-			"# reference https://docs.ultralytics.com/models"
+			"${1:model} = YOLO(\"yolov${2|8,5,9,10|}${3|n,s,m,l,x,c,e|}${4|.,-cls.,-seg.,-obb.,-pose.,-world.,-worldv2.|}pt\")",
+			"# reference https://docs.ultralytics.com/models",
+			"$0"
 		],
 		"description": "Initialize YOLO model."
 	},
@@ -18,8 +19,9 @@
 	"Ultralytics SAM Model": {
 		"prefix": "ultra.sam-model",
 		"body": [
-			"model = SAM(\"${1:sam_}${1|b,l|}.pt\")",
-			"# reference https://docs.ultralytics.com/models/sam/"
+			"${1:model} = SAM(\"sam_${2|b,l|}.pt\")",
+			"# reference https://docs.ultralytics.com/models/sam/",
+			"$0"
 		],
 		"description": "Shortcut to initialize SAM."
 	},
@@ -27,8 +29,9 @@
 	"Ultralytics MobileSAM Model": {
 		"prefix": "ultra.mobileam-model",
 		"body": [
-			"model = SAM(\"mobile_sam${1|s,x|}.pt\")",
-			"# reference https://docs.ultralytics.com/models/mobile-sam/"
+			"${1:model} = SAM(\"mobile_sam${2|s,x|}.pt\")",
+			"# reference https://docs.ultralytics.com/models/mobile-sam/",
+			"$0"
 		],
 		"description": "Shortcut to initialize MobileSAM."
 	},
@@ -36,8 +39,9 @@
 	"Ultralytics FastSAM Model": {
 		"prefix": "ultra.fastam-model",
 		"body": [
-			"model = FastSAM(\"FastSAM-${1|s,x|}.pt\")",
-			"# reference https://docs.ultralytics.com/models/fast-sam/"
+			"${1:model} = FastSAM(\"FastSAM-${2|s,x|}.pt\")",
+			"# reference https://docs.ultralytics.com/models/fast-sam/",
+			"$0"
 		],
 		"description": "Shortcut to initialize FastSAM."
 	},
@@ -45,8 +49,9 @@
 	"Ultralytics NAS Model": {
 		"prefix": "ultra.nas-model",
 		"body": [
-			"model = NAS(\"yolo_nas_${1|s,m,l|}.pt\")",
-			"# reference https://docs.ultralytics.com/models/yolo-nas"
+			"${1:model} = NAS(\"yolo_nas_${2|s,m,l|}.pt\")",
+			"# reference https://docs.ultralytics.com/models/yolo-nas",
+			"$0"
 		],
 		"description": "Shortcut to initialize YOLO-NAS model."
 	},
@@ -54,8 +59,9 @@
 	"Ultralytics RTDETR Model": {
 		"prefix": "ultra.rtdetr-model",
 		"body": [
-			"model = RTDETR(\"rtdetr-${2|l,x|}.pt\")",
-			"# reference https://docs.ultralytics.com/models/rtdetr/"
+			"${1:model} = RTDETR(\"rtdetr-${2|l,x|}.pt\")",
+			"# reference https://docs.ultralytics.com/models/rtdetr/",
+			"$0"
 		],
 		"description": "Shortcut to initialize RTDETR model."
 	}


### PR DESCRIPTION
- include VSCode extension marketplace link in Readme
- clean up readme file
- include `stream` keyword argument for `ultra.example.yolo-predict-kwords`
- add `ultra.yolo-export` snippet #14 