### PR TITLE
Update Readme and Snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,39 @@ A [Python snippets extension for VSCode](https://marketplace.visualstudio.com/it
   </p>
 </div>
 
-## Syntax
+## Installation
+
+### From the Web
+
+#### Method-1
+
+1. Visit the VSCode Extension Market place by going to https://marketplace.visualstudio.com/VSCode and search for `Ultralytics-Snippets`.
+
+#### Method-2
+
+1. Follow [this link](https://marketplace.visualstudio.com/items?itemName=Ultralytics.ultralytics-snippets) to visit the extension page directly.
+
+2. Click the "Install" button and allow your browser to launch a VSCode session.
+
+    ![VSCode marketplace extension install](https://github.com/user-attachments/assets/b40cc8e2-2353-4165-859a-c84eec070db6)
+
+### From VSCode
+
+1. Navigate to the Extensions menu, and search for `Ultralytics-Snippets`.
+
+2. Click the "Install" button.
+
+    ![VSCode extension menu](https://github.com/user-attachments/assets/9de46d22-ef7b-4765-ba2c-d0459cafa4dc)
+
+### From the CLI
+
+You can also install the latest version of the `Ultralytics-Snippets` VSCode extension using the following command.
+
+```sh
+code --install-extension ultralytics.ultralytics-snippets
+```
+
+## Snippets Syntax
 
 All snippets use the format:
 
@@ -95,15 +127,16 @@ for result in results:
 
 Shortcuts for initializing pretrained [Ultralytics models][models], like [YOLOv8].
 
-| Alias                  | Description                            | Reference                                             |
-| ---------------------- | -------------------------------------- | ----------------------------------------------------- |
-| `ultra.yolo-model`     | Shortcut to initialize YOLO model.     | [YOLOv5], [YOLOv8], [YOLOv9], [YOLOv10], [YOLO-World] |
-| `ultra.yolo-export`    | Shortcut to export YOLO model weights. | [Model Export]                                        |
-| `ultra.sam-model`      | Shortcut to initialize SAM.            | [SAM]                                                 |
-| `ultra.mobileam-model` | Shortcut to initialize MobileSAM.      | [Mobile SAM]                                          |
-| `ultra.fastam-model`   | Shortcut to initialize FastSAM.        | [FastSAM]                                             |
-| `ultra.nas-model`      | Shortcut to initialize YOLO-NAS model. | [YOLO-NAS]                                            |
-| `ultra.rtdetr-model`   | Shortcut to initialize RTDETR model.   | [RTDETR]                                              |
+| Alias                    | Description                                                  | Reference                                             |
+| ------------------------ | ------------------------------------------------------------ | ----------------------------------------------------- |
+| `ultra.yolo-model`       | Shortcut to initialize YOLO model.                           | [YOLOv5], [YOLOv8], [YOLOv9], [YOLOv10], [YOLO-World] |
+| `ultra.yolo-export`      | Shortcut to export YOLO model weights.                       | [Model Export]                                        |
+| `ultra.sam-model`        | Shortcut to initialize SAM.                                  | [SAM]                                                 |
+| `ultra.mobileam-model`   | Shortcut to initialize MobileSAM.                            | [Mobile SAM]                                          |
+| `ultra.fastam-model`     | Shortcut to initialize FastSAM.                              | [FastSAM]                                             |
+| `ultra.nas-model`        | Shortcut to initialize YOLO-NAS model.                       | [YOLO-NAS]                                            |
+| `ultra.rtdetr-model`     | Shortcut to initialize RTDETR model.                         | [RTDETR]                                              |
+| `ultra.yolo-world-model` | Shortcut to initialize YOLO-world model, with class prompts. | [YOLO-World]                                          |
 
 ### Snippet Example
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "ultralytics-snippets",
 	"displayName": "Ultralytics Snippets",
 	"description": "Snippets to use with the Ultralytics Python library.",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"publisher": "Ultralytics",
     "repository": {
         "type": "git",

--- a/snippets/examples.json
+++ b/snippets/examples.json
@@ -276,7 +276,7 @@
 			"    erasing=${67:0.4},                # (float) probability of random erasing during classification training (0-0.9), 0 means no erasing, must be less than 1.0.",
 			"    crop_fraction=${68:1.0},          # (float) image crop fraction for classification (0.1-1), 1.0 means no crop, must be greater than 0.",
 			")",
-			"# reference https://docs.ultralytics.com/modes/predict/"
+			"# reference https://docs.ultralytics.com/modes/train/"
 		],
 		"description": "Setup Ultralytics YOLO for training, with all keyword arguments and their default values."
 	}

--- a/snippets/examples.json
+++ b/snippets/examples.json
@@ -189,6 +189,7 @@
 			"    save_conf=${20:False},     # (bool) save results with confidence scores",
 			"    save_crop=${21:False},     # (bool) save cropped images with results",
 			"    stream=${22:False}         # (bool) for processing long videos or numerous images with reduced memory usage by returning a generator",
+			"    verbose=${23:True}         # (bool) enable/disable verbose inference logging in the terminal",
 			")",
 			"# reference https://docs.ultralytics.com/modes/predict/"
 		],

--- a/snippets/models.json
+++ b/snippets/models.json
@@ -90,6 +90,18 @@
 			"$0"
 		],
 		"description": "Shortcut to initialize RTDETR model."
+	},
+
+	"Ultralytics YOLO-World Model w/ Prompts": {
+		"prefix": "ultra.yolo-world-model",
+		"body": [
+			"${1:model} = YOLO(\"yolov8${2|s,m,l,x|}-${3|world,worldv2|}.pt\")",
+			"# configure custom classes with text prompts",
+			"$1.set_classes([${4:\"\"}])  # list of strings, with \"\" being a 'background' class",
+			"# reference https://docs.ultralytics.com/models/yolo-world/",
+			"$0"
+		],
+		"description": "Shortcut to initialize YOLO-World model with text prompts."
 	}
 
 


### PR DESCRIPTION
- fixes #18 
- adds `ultra.yolo-world-model` snippet, which includes setup for custom classes via text prompts
- include `verbose` argument for `ultra.example-yolo-predict-kwords`
- correct link to docs in `ultra.example-yolo-train-kwords`