### PR TITLE
Add Callbacks snippets & enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
   </p>
 </div>
 
-A [Python snippets extension for VSCode](https://marketplace.visualstudio.com/items?itemName=Ultralytics.ultralytics-snippets) to assist with development using the [Ultralytics package](https://github.com/ultralytics/ultralytics). These snippets will help you code with Ultralytics faster and help provide some boilerplate examples to test out. Open an Issue or a Pull Request to have your snippet added! 🚀
+A [Python snippets extension for VSCode](https://marketplace.visualstudio.com/items?itemName=Ultralytics.ultralytics-snippets) to assist with development using the [Ultralytics package](https://github.com/ultralytics/ultralytics). These snippets will help you code with Ultralytics faster and help provide some boilerplate examples to test out. Open an Issue or a Pull Request to have your snippet added! 🚀 Also works with [`neovim`](#use-with-neovim)!
 
 <div align="center">
   <p>
@@ -77,6 +77,7 @@ Import snippets are for common objects that would be imported from the Ultralyti
 | `ultra.import-seg2bbox`     | Import Ultralytics function to convert segmentation contours into horizontal bounding boxes. |
 | `ultra.import-box-convert`  | Import Ultralytics function for converting bounding box coordinates.                         |
 | `ultra.import-formats`      | Import Ultralytics supported file formats constant.                                          |
+| `ultra.import-task-result`  | Import task-based results class (generally helpful for type hinting).                        |
 
 ### Snippet Example
 
@@ -168,6 +169,7 @@ model = YOLO(f"yolov{version}{scale}{task}pt")
 | `ultra.util-auto-annotate`  | Use Ultralytics auto_annotate function to generate annotations.                | [`auto_annotator` fucntion][auto ann]  |
 | `ultra.util-annotator`      | Use Ultralytics Annotator class to draw box annotations                        | [`Annotator` class][ann]               |
 | `ultra.util-make-divisible` | Use Ultralytics make_divisible function to make a number divisible by another. | [`make_divisible` function][divisible] |
+| `ultra.util-callback`       | Shortcut for adding custom model callback for a defined function.              | [`callbacks`][callbacks]               |
 
 ### Snippet Example
 
@@ -202,6 +204,7 @@ The Example snippets are more "complete" blocks of code that can be used for boi
 | `ultra.example-fast-sam-predict`     | Setup Ultralytics FastSAM to perform inference (simple).                                                        |
 | `ultra.example-nas-predict`          | Setup Ultralytics NAS to perform inference (simple).                                                            |
 | `ultra.example-rtdetr-predict`       | Setup Ultralytics RT-DETR to perform inference (simple).                                                        |
+| `ultra.example-callback`             | Example showing how to add a custom callback function.                                                          |
 
 ### Snippet Example
 
@@ -223,6 +226,19 @@ for result in results:
 
 </p></details>
 
+
+## Use with `neovim`
+
+It's possible to use VSCode snippets by installing the [LuaSnip](https://github.com/L3MON4D3/LuaSnip) repo and then adding the following line into your configuration of `LuaSnip`:
+
+```
+require("luasnip.loaders.from_vscode").lazy_load({ paths = { "./ultralytics-snippets/" }, include = { "python" } })
+```
+
+Make sure that the path `"./ultralytics-snippets/"` is valid for your install location. 
+
+> [!NOTE] 
+> If the snippets don't work, try removing the comment lines at the top of each JSON file. These are ignored by VSCode, but might not be ignored by `neovim` or `LuaSnip`.
 
 
 [ann]: https://docs.ultralytics.com/usage/simple-utilities/#drawing-annotations
@@ -246,3 +262,4 @@ for result in results:
 [auto ann]: https://docs.ultralytics.com/reference/data/annotator/
 [divisible]: https://docs.ultralytics.com/reference/utils/ops/#ultralytics.utils.ops.make_divisible
 [Model Export]: https://docs.ultralytics.com/modes/export
+[callbacks]: https://docs.ultralytics.com/usage/callbacks/

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "ultralytics-snippets",
 	"displayName": "Ultralytics Snippets",
 	"description": "Snippets to use with the Ultralytics Python library.",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"publisher": "Ultralytics",
     "repository": {
         "type": "git",

--- a/snippets/examples.json
+++ b/snippets/examples.json
@@ -292,6 +292,6 @@
 			"",
 			"model.add_callback(\"${4|on_pretrain_routine_start,on_pretrain_routine_end,on_train_start,on_train_epoch_start,on_train_batch_start,optimizer_step,on_before_zero_grad,on_train_batch_end,on_train_epoch_end,on_fit_epoch_end,on_model_save,on_train_end,on_params_update,teardown,on_val_start,on_val_batch_start,on_val_batch_end,on_val_end,on_predict_start,on_predict_batch_start,on_predict_postprocess_end,on_predict_batch_end,on_predict_end,on_export_start,on_export_end|}\", $2)"
 		],
-		"description": "Example framework for adding a custom callback function."
+		"description": "Example showing how to add a custom callback function."
 	}
 }

--- a/snippets/examples.json
+++ b/snippets/examples.json
@@ -141,19 +141,18 @@
 		"body": [
 			"import numpy as np",
 			"from ultralytics import YOLO, ASSETS",
+			"from ultralytics.engine.results import Results, Boxes",
 			"",
 			"# NOTE class filtering should generally use the \"classes\" prediction argument.",
 			"# reference https://docs.ultralytics.com/modes/predict/#inference-arguments",
 			"",
 			"keep_classes = ${1:[0, 5]}  # person and bus classes",
-			"src=${2:ASSETS / \"bus.jpg\"}",
-			"model = YOLO(\"yolov8${3|n,s,m,l,x|}.pt\")",
-			"results = model.predict($2)  # use classes=$1 for filtering during prediction",
 			"",
-			"detections = results[0].boxes.data.cpu().numpy()",
-			"det_classes = detections[..., -2:]  # select only class indices",
-			"keep = np.isin(det_classes, keep_classes).any(axis=1)  # filter by class",
-			"filtered_detections = detections[keep]  # limit results to keep_classes only"
+			"model = YOLO(\"yolov8${2|n,s,m,l,x|}.pt\")",
+			"results:list[Results] = model.predict(ASSETS / \"bus.jpg\")  # use classes=$1 for filtering during prediction",
+			"",
+			"detections:Boxes = results[0].boxes.cpu().numpy()  # allows for access to all methods defined in Boxes",
+			"filtered_detections:Boxes = detections[np.isin(detections.cls, keep_classes)]  # limit results to keep_classes only"
 		],
 		"description": "Filter prediction results by class ID. Using \"classes\" keyword argument for prediction should be preferred."
 	},
@@ -281,7 +280,7 @@
 		"description": "Setup Ultralytics YOLO for training, with all keyword arguments and their default values."
 	},
 
-	"Ultralytics add custom callback":{
+	"Ultralytics Add Custom Callback":{
 		"prefix":"ultra.example-callback",
 		"body":[
 			"from ultralytics import YOLO",
@@ -292,6 +291,7 @@
     		"    ${3:pass}",
 			"",
 			"model.add_callback(\"${4|on_pretrain_routine_start,on_pretrain_routine_end,on_train_start,on_train_epoch_start,on_train_batch_start,optimizer_step,on_before_zero_grad,on_train_batch_end,on_train_epoch_end,on_fit_epoch_end,on_model_save,on_train_end,on_params_update,teardown,on_val_start,on_val_batch_start,on_val_batch_end,on_val_end,on_predict_start,on_predict_batch_start,on_predict_postprocess_end,on_predict_batch_end,on_predict_end,on_export_start,on_export_end|}\", $2)"
-		]
+		],
+		"description": "Example framework for adding a custom callback function."
 	}
 }

--- a/snippets/examples.json
+++ b/snippets/examples.json
@@ -290,7 +290,8 @@
 			"def ${2:callback_function}():",
     		"    ${3:pass}",
 			"",
-			"model.add_callback(\"${4|on_pretrain_routine_start,on_pretrain_routine_end,on_train_start,on_train_epoch_start,on_train_batch_start,optimizer_step,on_before_zero_grad,on_train_batch_end,on_train_epoch_end,on_fit_epoch_end,on_model_save,on_train_end,on_params_update,teardown,on_val_start,on_val_batch_start,on_val_batch_end,on_val_end,on_predict_start,on_predict_batch_start,on_predict_postprocess_end,on_predict_batch_end,on_predict_end,on_export_start,on_export_end|}\", $2)"
+			"model.add_callback(\"${4|on_pretrain_routine_start,on_pretrain_routine_end,on_train_start,on_train_epoch_start,on_train_batch_start,optimizer_step,on_before_zero_grad,on_train_batch_end,on_train_epoch_end,on_fit_epoch_end,on_model_save,on_train_end,on_params_update,teardown,on_val_start,on_val_batch_start,on_val_batch_end,on_val_end,on_predict_start,on_predict_batch_start,on_predict_postprocess_end,on_predict_batch_end,on_predict_end,on_export_start,on_export_end|}\", $2)",
+			"# See docs page on callbacks https://docs.ultralytics.com/usage/callbacks/ for more information"
 		],
 		"description": "Example showing how to add a custom callback function."
 	}

--- a/snippets/examples.json
+++ b/snippets/examples.json
@@ -279,5 +279,19 @@
 			"# reference https://docs.ultralytics.com/modes/train/"
 		],
 		"description": "Setup Ultralytics YOLO for training, with all keyword arguments and their default values."
+	},
+
+	"Ultralytics add custom callback":{
+		"prefix":"ultra.example-callback",
+		"body":[
+			"from ultralytics import YOLO",
+			"",
+			"model = YOLO(\"${1:yolov8n.pt}\")",
+			"",
+			"def ${2:callback_function}():",
+    		"    ${3:pass}",
+			"",
+			"model.add_callback(\"${4|on_pretrain_routine_start,on_pretrain_routine_end,on_train_start,on_train_epoch_start,on_train_batch_start,optimizer_step,on_before_zero_grad,on_train_batch_end,on_train_epoch_end,on_fit_epoch_end,on_model_save,on_train_end,on_params_update,teardown,on_val_start,on_val_batch_start,on_val_batch_end,on_val_end,on_predict_start,on_predict_batch_start,on_predict_postprocess_end,on_predict_batch_end,on_predict_end,on_export_start,on_export_end|}\", $2)"
+		]
 	}
 }

--- a/snippets/imports.json
+++ b/snippets/imports.json
@@ -19,6 +19,12 @@
 		"description": "Import Ultralytics Results class (usually for type hinting)."
 	},
 
+	"Import Task Results": {
+		"prefix": "ultra.import-task-result",
+		"body": "from ultralytics.engine.results import ${1|Boxes,Masks,Probs,Keypoints,OBB|}",
+		"description": "Import task-based results class (generally helpful for type hinting)."
+	},
+
 	"Import Annotator": {
 		"prefix": "ultra.import-annotator",
 		"body": "from ultralytics.data.annotator import auto_annotate",

--- a/snippets/utils.json
+++ b/snippets/utils.json
@@ -6,7 +6,9 @@
 		"body": [
 			"from ultralytics.data.annotator import auto_annotate",
 			"",
-			"auto_annotate(data=\"$1\", det_model=\"yolov8${2|n,s,m,l,x|}.pt\", sam_model=\"${3|sam_b,sam_l,mobile_sam,FastSAM-s,FastSAM-x|}.pt\", device=\"${4|cuda,cpu|}\", output_dir=\"$5\")"
+			"auto_annotate(data=\"$1\", det_model=\"yolov8${2|n,s,m,l,x|}.pt\", sam_model=\"${3|sam_b,sam_l,mobile_sam,FastSAM-s,FastSAM-x|}.pt\", device=\"${4|cuda,cpu|}\", output_dir=\"$5\")",
+			"# Docs example https://docs.ultralytics.com/usage/simple-utilities/#auto-labeling-annotations",
+			"# auto_annotate function reference https://docs.ultralytics.com/reference/data/annotator/#ultralytics.data.annotator.auto_annotate"
 		],
 		"description": "Use Ultralytics auto_annotate function to generate annotations."
 	},
@@ -40,7 +42,9 @@
 			"        rotated=${14:False}",
 			"    )",
 			"",
-			"img_annotated = ann.result()"
+			"img_annotated = ann.result()",
+			"# Docs example https://docs.ultralytics.com/usage/simple-utilities/#drawing-annotations",
+			"# Annotator class reference https://docs.ultralytics.com/reference/utils/plotting/#ultralytics.utils.plotting.Annotator"
 		],
 		"description": "Use Ultralytics Annotator class to draw box annotations."
 	},
@@ -50,7 +54,9 @@
 		"body": [
 			"from ultralytics.utils.ops import make_divisible",
 			"",
-			"make_divisible(${1:width}, ${2:divisor})"
+			"make_divisible(${1:width}, ${2:divisor})",
+			"# docs examples https://docs.ultralytics.com/usage/simple-utilities/#make-divisible",
+			"# make_divisible function reference https://docs.ultralytics.com/reference/utils/ops/#ultralytics.utils.ops.make_divisible"
 		],
 		"description": "Use Ultralytics make_divisible function to make a number divisible by another."
 	},
@@ -58,7 +64,8 @@
 	"Ultralytics Set Callback": {
 		"prefix": "ultra.util-callback",
 		"body": [
-			"${1:model}.add_callback(\"${2|on_pretrain_routine_start,on_pretrain_routine_end,on_train_start,on_train_epoch_start,on_train_batch_start,optimizer_step,on_before_zero_grad,on_train_batch_end,on_train_epoch_end,on_fit_epoch_end,on_model_save,on_train_end,on_params_update,teardown,on_val_start,on_val_batch_start,on_val_batch_end,on_val_end,on_predict_start,on_predict_batch_start,on_predict_postprocess_end,on_predict_batch_end,on_predict_end,on_export_start,on_export_end|}\", ${3:callable})"
+			"${1:model}.add_callback(\"${2|on_pretrain_routine_start,on_pretrain_routine_end,on_train_start,on_train_epoch_start,on_train_batch_start,optimizer_step,on_before_zero_grad,on_train_batch_end,on_train_epoch_end,on_fit_epoch_end,on_model_save,on_train_end,on_params_update,teardown,on_val_start,on_val_batch_start,on_val_batch_end,on_val_end,on_predict_start,on_predict_batch_start,on_predict_postprocess_end,on_predict_batch_end,on_predict_end,on_export_start,on_export_end|}\", ${3:callable})",
+			"# See docs page on callbacks https://docs.ultralytics.com/usage/callbacks/ for more information"
 		],
 		"description": "Shortcut for adding custom model callback for a defined function."
 	}

--- a/snippets/utils.json
+++ b/snippets/utils.json
@@ -53,6 +53,13 @@
 			"make_divisible(${1:width}, ${2:divisor})"
 		],
 		"description": "Use Ultralytics make_divisible function to make a number divisible by another."
+	},
+
+	"Ultralytics Set Callback": {
+		"prefix": "ultra.util-callback",
+		"body": [
+			"${1:model}.add_callback(\"${2|on_pretrain_routine_start,on_pretrain_routine_end,on_train_start,on_train_epoch_start,on_train_batch_start,optimizer_step,on_before_zero_grad,on_train_batch_end,on_train_epoch_end,on_fit_epoch_end,on_model_save,on_train_end,on_params_update,teardown,on_val_start,on_val_batch_start,on_val_batch_end,on_val_end,on_predict_start,on_predict_batch_start,on_predict_postprocess_end,on_predict_batch_end,on_predict_end,on_export_start,on_export_end|}\", ${3:callable})"
+		]
 	}
 
 }

--- a/snippets/utils.json
+++ b/snippets/utils.json
@@ -59,7 +59,8 @@
 		"prefix": "ultra.util-callback",
 		"body": [
 			"${1:model}.add_callback(\"${2|on_pretrain_routine_start,on_pretrain_routine_end,on_train_start,on_train_epoch_start,on_train_batch_start,optimizer_step,on_before_zero_grad,on_train_batch_end,on_train_epoch_end,on_fit_epoch_end,on_model_save,on_train_end,on_params_update,teardown,on_val_start,on_val_batch_start,on_val_batch_end,on_val_end,on_predict_start,on_predict_batch_start,on_predict_postprocess_end,on_predict_batch_end,on_predict_end,on_export_start,on_export_end|}\", ${3:callable})"
-		]
+		],
+		"description": "Shortcut for adding custom model callback for a defined function."
 	}
 
 }

--- a/utils/parse.py
+++ b/utils/parse.py
@@ -2,20 +2,53 @@ import json
 from pathlib import Path
 from typing import LiteralString
 
-'''
-Write a python function to parse all the json files found in the snippets directory, and create a markdown formatted table from the "prefix" and "description" keys of each entry. The markdown table should calculate the max space needed for each column based on the contexts of the json file.
-'''
-
 class JSONDecoderWithComments(json.JSONDecoder):
+    """
+    A custom JSON decoder that removes comments from the input string before decoding.
+
+    This class extends the `json.JSONDecoder` class and overrides the `decode` method to remove comments
+    from the input string before decoding it into a Python object.
+
+    Attributes:
+        parse_comment (bool): Flag indicating whether to parse comments or not.
+
+    Methods:
+        decode(s, *args, **kwargs): Decodes the input string after removing comments.
+        strip_comments(s): Removes comments from the input string.
+    """
+    
+    
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.parse_comment = False
-
+    
+    
     def decode(self, s, *args, **kwargs) -> dict|list|str:
+        """
+        Decodes the input string after removing comments.
+
+        Args:
+            s (str): The input string to decode.
+            *args: Additional arguments to pass to the `json.JSONDecoder.decode` method.
+            **kwargs: Additional keyword arguments to pass to the `json.JSONDecoder.decode` method.
+
+        Returns:
+            dict|list|str: The decoded Python object.
+        """
         s = self.strip_comments(s)
         return super().decode(s, *args, **kwargs)
     
+
     def strip_comments(self, s) -> LiteralString:
+        """
+        Removes comments from the input string.
+
+        Args:
+            s (str): The input string to remove comments from.
+
+        Returns:
+            LiteralString: The input string with comments removed.
+        """
         lines = s.split("\n")
         stripped_lines = []
         for line in lines:
@@ -31,7 +64,17 @@ class JSONDecoderWithComments(json.JSONDecoder):
         return "\n".join(stripped_lines)
 
 
-def parse_json_files(directory):
+def parse_json_files(directory:str|Path) -> LiteralString | str:
+    """
+    Parses all JSON files in the specified directory and generates a markdown table.
+
+    Args:
+        directory (str or Path): The directory path containing the JSON files.
+
+    Returns:
+        LiteralString or str: The generated markdown table.
+    """
+
     table = []
     max_prefix_length = 0
     max_description_length = 0
@@ -68,6 +111,6 @@ def parse_json_files(directory):
     return markdown_table
 
 # Example usage
-directory = r"Q:\ML_dev\ultra_snippets\ultralytics-snippets\snippets"
+directory = Path.cwd() / "ultralytics-snippets/snippets"
 markdown_table = parse_json_files(directory)
 print(markdown_table)


### PR DESCRIPTION
closes #20 #21 

- Add example snippet for adding custom callbacks
- Add snippet for setting custom callback
- Modify filtering results example snippet to retain Boxes API methods
- Add import snippet for task-results classes (`Boxes`, `Masks`, `Probs`, `Keypoints`, `OBB`)
- Include docs page links for utility snippets
- Clean up utils/parse.py and add docstrings
- Update Readme
  - include new snippets
  - add section about using `neovim` including note about removing JSON comments